### PR TITLE
Fix for github actions warning about inputs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - id: metadata
+      name: Get Git Metadata
+      uses: WPMedia/git-version-action@v1
     - uses: ./
       with:
         token: ${{ secrets.SLACK_BOT_TOKEN }}
-        payload: '{ "channel": "#publishing-tools-ops", "text": "Slack message test for `${{ github.repository }}@${{ github.sha }}` " }'
+        payload: '{ "channel": "#publishing-tools-ops", "text": "Slack message test for `${{ github.repository }}@${{ steps.metadata.outputs.git_version }}` " }'

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,10 @@
 name: 'Slack'
 description: 'This GitHub action wraps the Slack API method for posting to channels, private groups, and DMs.'
-outputs:
-  slack_token:
+inputs:
+  token:
+    required: true
   payload:
+    required: true
 runs:
   using: 'node12'
   main: 'dist/index.js'


### PR DESCRIPTION
Fixes a warning in github workflows when using the action:

<img width="898" alt="Screen Shot 2020-07-22 at 3 07 36 PM" src="https://user-images.githubusercontent.com/3671561/88217841-208e1b00-cc2d-11ea-9777-f6470cc9dbf4.png">

Testing:
Compare the unit test of [this branch](https://github.com/WPMedia/slack-action/actions/runs/178883083) to the [1.1.0 release](https://github.com/WPMedia/slack-action/actions/runs/146410009). Warning is in the release (and previous actions) but not in this branch.